### PR TITLE
FIX for german minimum temperature string

### DIFF
--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -54,7 +54,7 @@
     <string name="comfortTemperature">Komfort-Temperatur</string>
     <string name="ecoTemperature">Eco-Temperatur</string>
     <string name="maximumTemperature">Maximaltemperatur</string>
-    <string name="minimumTemperature">Maximaltemperatur</string>
+    <string name="minimumTemperature">Minimaltemperatur</string>
     <string name="forecast">Vorhersage</string>
     <string name="pressure">Luftdruck</string>
     <string name="pressureNN">Luftdruck NN</string>


### PR DESCRIPTION
Changed wrong entry "Maximaltemperatur" to correct value "Minimaltemperatur"
